### PR TITLE
ci: remove unsupported platforms

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -8,8 +8,6 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - '10'
-          - '12'
           - '14'
           - '16'
           - '18'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,7 +8,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - '2.7'
           - '3.5'
           - '3.6'
           - '3.7'

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,7 +9,6 @@ jobs:
       matrix:
         ruby:
           - ruby-2.1
-          - ruby-2.2
           - ruby-2.3
           - ruby-2.4
           - ruby-2.5


### PR DESCRIPTION
In GH Actions test matrices remove the versions that are not available by default any more.